### PR TITLE
LatestPostList: fix new class name requirements for 2.5 plugins

### DIFF
--- a/LatestPostList/class.latestpostlist.plugin.php
+++ b/LatestPostList/class.latestpostlist.plugin.php
@@ -28,7 +28,7 @@ $PluginInfo['LatestPostList'] = array(
    'License' => 'GPLv3'
 );
 
-class LatestPostList extends Gdn_Plugin {
+class LatestPostListPlugin extends Gdn_Plugin {
 
 	// runs once every page load
 	public function __construct() {


### PR DESCRIPTION
Class name must end with "...Plugin"